### PR TITLE
Update yml so that upload of files to S3 works

### DIFF
--- a/route53-ddns.yml
+++ b/route53-ddns.yml
@@ -348,7 +348,7 @@ Resources:
               zip_archive = zipfile.ZipFile(zip_file, 'w')
               zip_archive.write('/tmp/index.py', 'index.py')
               zip_archive.close()
-              zip_file = open(zip_file, 'r')
+              zip_file = open(zip_file, 'rb')
           
               ## Put the archive in S3
               try:


### PR DESCRIPTION
Apparently in Python3 the binary flag is mandatory for reading binary files (in this case the zip file previously created). Creating the Python3 version using CloudFormation now works.

*Issue #, if available:*
33

*Description of changes:*
Changed parameters for opening the zip file to include the binary flag.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
