### PR TITLE
Fixed PS string replacement order

### DIFF
--- a/route53-ddns-client-lite.ps1
+++ b/route53-ddns-client-lite.ps1
@@ -23,7 +23,7 @@ If (!($myHostname.EndsWith("."))){
 $getURL = $myAPIURL + "?mode=get"
 $webRequest = Invoke-WebRequest -Headers @{"x-api-key"="$myAPIKEY"} -URI $getURL
 
-$myIP = $webRequest.Content.Replace('{"return_message": "', '').Replace('", "return_status": "success"}','')
+$myIP = $webRequest.Content.Replace('{"return_status": "success", "return_message": "', '').Replace('"}','')
 
 $message = $myIP + $myHostname + $mySharedSecret
 $sha256 = New-Object System.Text.StringBuilder 


### PR DESCRIPTION
*Description of changes:*
In Python 3.8, the order of attributes changed compared to Python 2.7 -- specifically, the order of "return_message" and "return_status" from the initial web request changed.

Updated the ps1 file to properly extract the IP address before issuing the request to update the IP address.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
