### PR TITLE
enforce strong DNS name matching

### DIFF
--- a/lambda/index.py
+++ b/lambda/index.py
@@ -51,8 +51,7 @@ def route53_client(execution_mode, route_53_zone_id,
                 MaxItems='1'
             )
             try:
-                if current_route53_record_set['ResourceRecordSets'] and \
-                   current_route53_record_set['ResourceRecordSets'][0]['Name'].rstrip('.') == route_53_record_name.rstrip('.'):
+                if current_route53_record_set['ResourceRecordSets'][0]['Name'].rstrip('.') == route_53_record_name.rstrip('.'):
                     currentroute53_ip = current_route53_record_set['ResourceRecordSets'][0]['ResourceRecords'][0]['Value']
                 else:
                     currentroute53_ip = '0'

--- a/lambda/index.py
+++ b/lambda/index.py
@@ -48,9 +48,14 @@ def route53_client(execution_mode, route_53_zone_id,
                 HostedZoneId=route_53_zone_id,
                 StartRecordName=route_53_record_name,
                 StartRecordType=route_53_record_type,
+                MaxItems='1'
             )
             try:
-                currentroute53_ip = current_route53_record_set['ResourceRecordSets'][0]['ResourceRecords'][0]['Value']
+                if current_route53_record_set['ResourceRecordSets'] and \
+                   current_route53_record_set['ResourceRecordSets'][0]['Name'].rstrip('.') == route_53_record_name.rstrip('.'):
+                    currentroute53_ip = current_route53_record_set['ResourceRecordSets'][0]['ResourceRecords'][0]['Value']
+                else:
+                    currentroute53_ip = '0'
             except:
                 currentroute53_ip = '0'
             return {'return_status': 'success', 'return_message': currentroute53_ip}


### PR DESCRIPTION
*Issue #, if available:*

if `host2.dyn.example.com` is already configured with the correct client address, attempting to update `host1.dyn.example.com` from the same client was returning _"Your IP address matches the current Route53 DNS record."_ if `host1` DNS entry is not existing. This is because the boto3 function `list_resource_record_sets` results begin with the first resource record set that has a name **greater or equal** than the value of `name`, and would return the IP of `host2`.

*Description of changes:*
- Check that returned record matches the desired route_53_record_name
- Add MaxItems='1' to optimize result size (we are looking for just one record)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
