### PR TITLE
Upgrade Lambda runtime from Python 3.13 to 3.14

### DIFF
--- a/dyndns/dyndns_stack.py
+++ b/dyndns/dyndns_stack.py
@@ -54,7 +54,7 @@ class DyndnsStack(cdk.Stack):
 
 
         fn = lambda_.Function(self, "dyndns_fn",
-            runtime=lambda_.Runtime.PYTHON_3_13,
+            runtime=lambda_.Runtime.PYTHON_3_14,
             architecture=lambda_.Architecture.ARM_64,
             handler="index.lambda_handler",
             code=lambda_.Code.from_asset("lambda"),


### PR DESCRIPTION
Was running into issue similar to this: https://github.com/cdklabs/cdk-nag/issues/1528

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
