### PR TITLE
Remove DynamoDB dependency and implement simplified domain validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,13 +9,11 @@ This repository contains all the required code to deploy a Serverless Dynamic DN
 CDK will manage the deployment of the following resources:
 
 - Lambda Function
-- DynamoDB Table
 - Lambda Function IAM Role
 
 The Lambda function will be configured with a FunctionURL for PUBLIC invocation.
 The Lambda IAM Role will have the following permissions in addition to the standard Lambda role:
 
-- READ (all actions) for the deployed DynamoDB Table
 - Route53 List and Change record set
 
 To deploy the CDK stack to an AWS account is suggested to use a CloudShell session: 
@@ -50,20 +48,32 @@ Deploy the stack
 
 ## Configuration
 
+### Domain Validation
+
+The solution supports two domain validation modes configured via Lambda environment variables:
+
+**Wildcard Mode** (default):
+- Uses regex pattern matching to validate hostnames
+- Default pattern: `^[a-z0-9\-]+\.dyn\.orbit\.me\.uk$`
+- Allows any subdomain under the specified pattern
+- Configure via `VALIDATION_MODE=wildcard` and `ALLOWED_PATTERN` environment variables
+
+**Hardcoded Mode**:
+- Validates against an exact list of allowed domains
+- Configure via `VALIDATION_MODE=hardcoded` and `ALLOWED_DOMAINS` (comma-separated) environment variables
+
 ### Route53 Hosted zone and record set
 
-A Route53 Hosted Zone (https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/hosted-zones-working-with.html) is required to update the hostname, the Hosted Zone ID must be included in the configuration and stored in the deployed DynamoDB table using the hostname as key and in the _data_ attribute the following JSON object ([Sample configuration](www.example.com.json)):
+A Route53 Hosted Zone (https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/hosted-zones-working-with.html) is required to update the hostname. The configuration is now stored in Lambda environment variables instead of DynamoDB:
 
-```JSON
-{
-  "route_53_zone_id": "XYZ1234567890",
-  "route_53_record_ttl": 60,
-  "shared_secret": "SHARED_SECRET_1"
-}
-```
+- `ROUTE53_ZONE_ID`: The Route53 Hosted Zone ID (e.g., "XYZ1234567890")
+- `ROUTE53_RECORD_TTL`: DNS record TTL in seconds (default: 60)
+- `SHARED_SECRET`: Shared secret for hash validation
+- `VALIDATION_MODE`: "wildcard" or "hardcoded"
+- `ALLOWED_PATTERN`: Regex pattern for wildcard mode
+- `ALLOWED_DOMAINS`: Comma-separated list for hardcoded mode
 
-To facilitate the configuration process execute the included [newrecord.py](newrecord.py) Python script.
-(Execute this script for each hostname to be configured)
+To facilitate the configuration process execute the included [newrecord.py](newrecord.py) Python script:
 
 > `python3 newrecord.py`
 
@@ -107,7 +117,7 @@ If the default configuration is correct, just press `Enter` to continue, if not 
 
 ### Shared secret
 
-The next prompt will ask to type a shared secret and confirm it. The shared secret will be saved in the JSON configuration and hashed when invoking the Lambda function. Lambda will read the shared secret from DynamoDB and hash it to validate the request is authorized. For example here `SHARED_SECRET_123` is provided.
+The next prompt will ask to type a shared secret and confirm it. The shared secret will be saved in the Lambda environment variables and hashed when invoking the Lambda function. Lambda will read the shared secret from its environment and hash it to validate the request is authorized. For example here `SHARED_SECRET_123` is provided.
 
 ```bash
 Enter the secret for the new record set.

--- a/dyndns/dyndns_stack.py
+++ b/dyndns/dyndns_stack.py
@@ -1,7 +1,6 @@
 import aws_cdk as cdk
 import aws_cdk.aws_s3 as s3
 import aws_cdk.aws_lambda as lambda_
-import aws_cdk.aws_dynamodb as dynamodb
 import aws_cdk.aws_iam as iam
 from cdk_nag import AwsSolutionsChecks, NagSuppressions, NagPackSuppression
 
@@ -9,15 +8,7 @@ class DyndnsStack(cdk.Stack):
 
     def __init__(self, scope: cdk.App, construct_id: str, **kwargs) -> None:
         super().__init__(scope, construct_id, **kwargs)
-     
-        
-        #Create dynamoDB table
-        table = dynamodb.Table(self, "dyndns_db",
-            partition_key=dynamodb.Attribute(name="hostname", type=dynamodb.AttributeType.STRING),
-            removal_policy=cdk.RemovalPolicy.DESTROY,
-            point_in_time_recovery=True                   
-        )
-        
+
         #Create Lambda role
         fn_role = iam.Role(self, "dyndns_fn_role",
             assumed_by = iam.ServicePrincipal("lambda.amazonaws.com"),
@@ -60,9 +51,14 @@ class DyndnsStack(cdk.Stack):
             code=lambda_.Code.from_asset("lambda"),
             role=fn_role,
             timeout=cdk.Duration.seconds(8),
-            #Provide DynammoDB table name as enviroment variable
+            #Provide configuration as environment variables
             environment={
-                "ddns_config_table":table.table_name
+                "VALIDATION_MODE": "wildcard",  # Options: "hardcoded" or "wildcard"
+                "ALLOWED_PATTERN": r"^[a-z0-9\-]+\.dyn\.orbit\.me\.uk$",  # For wildcard mode
+                "ALLOWED_DOMAINS": "",  # For hardcoded mode: comma-separated list
+                "ROUTE53_ZONE_ID": "",  # Must be set via CDK context or updated here
+                "ROUTE53_RECORD_TTL": "60",  # DNS record TTL in seconds
+                "SHARED_SECRET": ""  # Must be set via CDK context or updated here
             }
         )            
 
@@ -75,9 +71,6 @@ class DyndnsStack(cdk.Stack):
                 allowed_origins=["*"]
             )
         )
-
-        #Give lambda permissions to read DynamoDB table
-        table.grant_read_data(fn)
 
         #Suppress AwsSolutions-IAM5 triggered by Resources::*
         NagSuppressions.add_resource_suppressions(

--- a/lambda/index.py
+++ b/lambda/index.py
@@ -11,29 +11,47 @@ import os
 from botocore.exceptions import ClientError
 
 '''
-This function pulls the json config data from DynamoDB and returns a python dictionary.
-It is called by the run_set_mode function.
+This function validates the hostname against configured allowed domains.
+Supports two modes:
+- hardcoded: Exact match against comma-separated list in ALLOWED_DOMAINS
+- wildcard: Regex pattern match against ALLOWED_PATTERN
+Returns True if hostname is allowed, False otherwise.
 '''
-def read_config(key_hostname):
-    # Define the dynamoDB client
-    dynamodb = boto3.client("dynamodb")
-    # Retrieve data based on key_hostname
-    response = dynamodb.get_item(
-        TableName=os.environ.get("ddns_config_table"),
-        Key={'hostname': {'S': key_hostname}}
-    )
-    # Return the json as a dictionary.
-    return json.loads(response["Item"]["data"]["S"])
+def validate_hostname(hostname):
+    validation_mode = os.environ.get("VALIDATION_MODE", "wildcard").lower()
+
+    if validation_mode == "hardcoded":
+        # Get comma-separated list of allowed domains
+        allowed_domains_str = os.environ.get("ALLOWED_DOMAINS", "")
+        if not allowed_domains_str:
+            return False
+
+        # Split and strip whitespace from each domain
+        allowed_domains = [d.strip() for d in allowed_domains_str.split(",")]
+
+        # Check for exact match (case-insensitive)
+        return hostname.lower() in [d.lower() for d in allowed_domains]
+
+    elif validation_mode == "wildcard":
+        # Get regex pattern for allowed domains
+        allowed_pattern = os.environ.get("ALLOWED_PATTERN", r"^[a-z0-9\-]+\.dyn\.orbit\.me\.uk$")
+
+        # Match hostname against pattern
+        return bool(re.match(allowed_pattern, hostname.lower()))
+
+    else:
+        # Unknown validation mode
+        return False
 
 '''
-    This function takes the python dictionary returned from read_configThis function defines the interaction with Route 53.
-    It is called by the run_set_mode function.
-    @param execution_mode defines whether to set or get a DNS record
-    @param route_53_zone_id defines the id for the DNS zone
-    @param route_53_record_name defines the record, ie www.acme.com.
-    @param route_53_record_ttl defines defines the DNS record TTL
-    @param route_53_record_type defines record type, should always be 'a'
-    @param public_ip defines the current public ip of the client
+This function defines the interaction with Route 53.
+It is called by the run_set_mode function.
+@param execution_mode defines whether to set or get a DNS record
+@param route_53_zone_id defines the id for the DNS zone
+@param route_53_record_name defines the record, ie www.acme.com.
+@param route_53_record_ttl defines defines the DNS record TTL
+@param route_53_record_type defines record type, should always be 'a'
+@param public_ip defines the current public ip of the client
 '''
 def route53_client(execution_mode, route_53_zone_id,
                    route_53_record_name, route_53_record_ttl,
@@ -99,26 +117,25 @@ If not it calls route53_client to set the DNS record to the current IP.
 It is called by the main lambda_handler function.
 '''
 def run_set_mode(ddns_hostname, validation_hash, source_ip):
-    # Try to read the config, and error if you can't.
-    try:
-        full_config=read_config(ddns_hostname)
-    except:
-        return_status='fail'
-        return_message='There was an issue finding '\
-            'or reading '+ddns_hostname+' configuration from dynamoDB table: ' + \
-            os.environ.get("ddns_config_table")
+    # Validate that the hostname is allowed
+    if not validate_hostname(ddns_hostname):
+        return_status = 'fail'
+        return_message = 'Hostname ' + ddns_hostname + ' is not allowed. Domain validation failed.'
         return [403, {'return_status': return_status,
                 'return_message': return_message}]
 
-    # Get the section of the config related to the requested hostname.
-    record_config_set=full_config  # [ddns_hostname]
-    # the Route 53 Zone you created for the script
-    route_53_zone_id=record_config_set['route_53_zone_id']
-    # record TTL (Time To Live) in seconds tells DNS servers how long to cache
-    # the record.
-    route_53_record_ttl=record_config_set['route_53_record_ttl']
-    route_53_record_type="A"
-    shared_secret=record_config_set['shared_secret']
+    # Read configuration from environment variables
+    route_53_zone_id = os.environ.get("ROUTE53_ZONE_ID")
+    route_53_record_ttl = int(os.environ.get("ROUTE53_RECORD_TTL", "60"))
+    route_53_record_type = "A"
+    shared_secret = os.environ.get("SHARED_SECRET")
+
+    # Validate required environment variables
+    if not route_53_zone_id or not shared_secret:
+        return_status = 'fail'
+        return_message = 'Server configuration error: Missing required environment variables'
+        return [500, {'return_status': return_status,
+                'return_message': return_message}]
 
     # Validate that the client passed a sha256 hash
     # regex checks for a 64 character hex string.

--- a/newrecord.py
+++ b/newrecord.py
@@ -1,7 +1,6 @@
 import time
 import boto3
 route53 = boto3.client('route53')
-dynamodb = boto3.client('dynamodb')
 awslambda = boto3.client('lambda')
 cloudformation = boto3.client('cloudformation')
 
@@ -18,15 +17,17 @@ except:
     exit()
 
 
-# Get dynamodb table name and Lambda Function URL
+# Get Lambda Function name
 resources = cloudformation.list_stack_resources(StackName='DyndnsStack')
+lambdafn = None
 for resource in resources['StackResourceSummaries']:
-    if resource['ResourceType'] == 'AWS::DynamoDB::Table':
-        table = resource['PhysicalResourceId']
     if resource['ResourceType'] == 'AWS::Lambda::Function':
         lambdafn = resource['PhysicalResourceId']
-    else:
-        pass
+        break
+
+if not lambdafn:
+    print("Lambda function not found in stack.")
+    exit()
 
 lambdaurl = awslambda.get_function_url_config(
     FunctionName=lambdafn)['FunctionUrl']
@@ -109,33 +110,45 @@ print('#                                            #')
 print('##############################################')
 confirm=input()
 if confirm == 'y':
-    # Write configuration in dynamodb
-    print('\nSaving configuration...')
+    # Update Lambda environment variables
+    print('\nUpdating Lambda environment variables...')
     try:
-        dynamodb.put_item(
-            TableName= table,
-            Item = {
-                'hostname': {
-                    'S': hostname
-                },
-                'data': {
-                    'S': '{"route_53_zone_id": "'+hzid+'","route_53_record_ttl": '+str(ttl)+',"shared_secret": "'+secret+'"}'
-                }
-            }
+        # Get current environment variables
+        lambda_config = awslambda.get_function_configuration(FunctionName=lambdafn)
+        current_env = lambda_config.get('Environment', {}).get('Variables', {})
+
+        # Update with new configuration
+        current_env['ROUTE53_ZONE_ID'] = hzid
+        current_env['ROUTE53_RECORD_TTL'] = str(ttl)
+        current_env['SHARED_SECRET'] = secret
+
+        # Update the Lambda function
+        awslambda.update_function_configuration(
+            FunctionName=lambdafn,
+            Environment={'Variables': current_env}
         )
+
         print('Configuration saved.\n')
         print('#####################################################')
         print('#                                                   #')
         print('# The Serverless Dynamic DNS solution is now ready. #')
         print('#                                                   #')
         print('#####################################################')
+        print('\nConfiguration details:')
+        print('  Hosted zone ID: ' + hzid)
+        print('  Record TTL: ' + str(ttl))
+        print('  Validation mode: ' + current_env.get('VALIDATION_MODE', 'wildcard'))
+        if current_env.get('VALIDATION_MODE', 'wildcard') == 'wildcard':
+            print('  Allowed pattern: ' + current_env.get('ALLOWED_PATTERN', ''))
+        else:
+            print('  Allowed domains: ' + current_env.get('ALLOWED_DOMAINS', ''))
         print(
             '\n'+hostname+' can be updated with the following command:')
         print("./dyndns.sh -m set -u "+lambdaurl +
               " -h "+hostname+" -s "+secret)
         print('\n##########################################################################################\n')
-    except:
-        print("Could not save configuration.")
+    except Exception as e:
+        print("Could not save configuration: " + str(e))
         exit()
 else:
     print('Aborting.')


### PR DESCRIPTION
This commit removes all DynamoDB dependencies and implements a configurable domain validation system using Lambda environment variables.

Changes:
- Lambda function (lambda/index.py):
  - Removed DynamoDB client initialization and read_config function
  - Added validate_hostname function supporting two modes:
    * Wildcard: regex pattern matching (default)
    * Hardcoded: exact match against comma-separated list
  - Configuration now read from environment variables instead of DynamoDB
  - Added validation for required environment variables

- CDK stack (dyndns/dyndns_stack.py):
  - Removed DynamoDB table resource and import
  - Removed DynamoDB IAM permissions
  - Added new Lambda environment variables:
    * VALIDATION_MODE: "wildcard" or "hardcoded"
    * ALLOWED_PATTERN: regex pattern for wildcard mode
    * ALLOWED_DOMAINS: comma-separated list for hardcoded mode
    * ROUTE53_ZONE_ID: Route53 hosted zone ID
    * ROUTE53_RECORD_TTL: DNS record TTL
    * SHARED_SECRET: authentication secret

- Configuration utility (newrecord.py):
  - Removed DynamoDB client and table operations
  - Updated to use Lambda UpdateFunctionConfiguration API
  - Configuration now stored in Lambda environment variables

- Documentation (README.md):
  - Updated architecture description to remove DynamoDB references
  - Added domain validation mode documentation
  - Updated configuration section for environment variables
  - Updated shared secret description

Error Handling:
- 403: Domain not allowed (fails validation)
- 400: Invalid hostname format or missing parameters
- 500: Route53 errors or missing environment variables

API contract and Route53 logic remain unchanged.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
